### PR TITLE
feat(jsii-interface): limit updated variables for updateprops

### DIFF
--- a/src/jsii-interface.ts
+++ b/src/jsii-interface.ts
@@ -114,6 +114,14 @@ export class JsiiInterface extends Component {
               return {
                 ...p,
                 ...options.updateProps?.[p.name],
+                docs: {
+                  ...p.docs,
+                  ...options.updateProps?.[p.name].docs,
+                  custom: {
+                    ...p.docs?.custom,
+                    ...options.updateProps?.[p.name].docs?.custom,
+                  },
+                },
               };
             }
             return p;

--- a/test/__snapshots__/jsii-interface.test.ts.snap
+++ b/test/__snapshots__/jsii-interface.test.ts.snap
@@ -38,6 +38,7 @@ export interface MyInterface {
   readonly filename?: string;
   /**
    * New summary
+   * @default "projenrc"
    * @stability stable
    */
   readonly projenCodeDir: string;

--- a/test/jsii-interface.test.ts
+++ b/test/jsii-interface.test.ts
@@ -84,6 +84,7 @@ test('can update props', () => {
   // ASSERT
   expect(renderedFile).toContain('New summary');
   expect(renderedFile).toContain('@stability stable');
+  expect(renderedFile).toContain('@default "projenrc"');
   expect(renderedFile).toMatchSnapshot();
 });
 


### PR DESCRIPTION
I was trying to update only the default value for props but the currently other properties like summary are also removed from the property. This PR is the limit the updates to a more granular set.
